### PR TITLE
Update mongo lock index names

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -141,10 +141,10 @@ func (c *Client) CreateIndexes(ctx context.Context) error {
 		},
 
 		// Optional.
-		{Keys: bson.M{"exclusive.LockId": 1}},
-		{Keys: bson.M{"exclusive.ExpiresAt": 1}},
-		{Keys: bson.M{"shared.locks.LockId": 1}},
-		{Keys: bson.M{"shared.locks.ExpiresAt": 1}},
+		{Keys: bson.M{"exclusive.lockId": 1}},
+		{Keys: bson.M{"exclusive.expiresAt": 1}},
+		{Keys: bson.M{"shared.locks.lockId": 1}},
+		{Keys: bson.M{"shared.locks.expiresAt": 1}},
 	}
 
 	for _, idx := range indexes {


### PR DESCRIPTION
Fix index naming so that they're used ( lowercase index field names are required to be used, as specified in the structs )