### PR TITLE
Add comments feature to locking

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -726,6 +726,9 @@ func statusFromLock(l lock) LockStatus {
 	if l.Host != nil {
 		ls.Host = *l.Host
 	}
+	if l.Comment != nil {
+		ls.Comment = *l.Comment
+	}
 	if l.CreatedAt != nil {
 		ls.CreatedAt = *l.CreatedAt
 	}

--- a/lock.go
+++ b/lock.go
@@ -41,6 +41,8 @@ type LockDetails struct {
 	Owner string
 	// The host that the lock is being created from.
 	Host string
+	// Comment to add context for the lock.
+	Comment string
 	// The time to live (TTL) for the lock, in seconds. Setting this to 0
 	// means that the lock will not have a TTL.
 	TTL uint
@@ -58,6 +60,8 @@ type LockStatus struct {
 	Owner string
 	// The host that the lock was created from.
 	Host string
+	// Comment to add context for the lock.
+	Comment string
 	// The time that the lock was created at.
 	CreatedAt time.Time
 	// The time that the lock was renewed at, if applicable.
@@ -91,6 +95,7 @@ type lock struct {
 	LockId    *string            `bson:"lockId"`
 	Owner     *string            `bson:"owner"`
 	Host      *string            `bson:"host"`
+	Comment   *string            `bson:"comment"`
 	CreatedAt *time.Time         `bson:"createdAt"`
 	RenewedAt *time.Time         `bson:"renewedAt"`
 	ExpiresAt *time.Time         `bson:"expiresAt"` // How TTLs are stored internally.
@@ -691,6 +696,9 @@ func lockFromDetails(lockId string, ld LockDetails) lock {
 	}
 	if ld.Host != "" {
 		lock.Host = &ld.Host
+	}
+	if ld.Comment != "" {
+		lock.Comment = &ld.Comment
 	}
 	if ld.TTL > 0 {
 		e := now.Add(time.Duration(ld.TTL) * time.Second)


### PR DESCRIPTION
# Description (copied from commit message)

This commit adds the ability to lock with comments. These will be stored as an optional field in the Mongo document if non-empty. Comments are useful for adding context about why the lock was created in the first place. This can be useful in organizations where locking and unlocking of resources requires coordination.

# Testing

Had to change this port to `3000`: https://github.com/square/mongo-lock/blob/701ecf357cd7478636992e53dfde54115414a6dd/lock_test.go#L37 and then

```bash
$ docker run --rm -p "3000:27017" mongo &
$ go test `go list ./... | grep -v "/vendor/"` --race
ok  	github.com/square/mongo-lock	7.001s
$
```
