### PR TITLE
`Renew`: Support DocumentDB and Shared Lock Bugfix

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -535,7 +535,7 @@ func (c *Client) Renew(ctx context.Context, lockId string, ttl uint) ([]LockStat
 				"resource":         lock.Resource,
 				"exclusive.lockId": lock.LockId,
 				"exclusive.expiresAt": bson.M{
-					"$gt": minExpiresAt,
+					"$gt": primitive.NewDateTimeFromTime(minExpiresAt),
 				},
 			}
 
@@ -549,10 +549,14 @@ func (c *Client) Renew(ctx context.Context, lockId string, ttl uint) ([]LockStat
 
 		if lock.Type == LOCK_TYPE_SHARED {
 			selector = bson.M{
-				"resource":            lock.Resource,
-				"shared.locks.lockId": lock.LockId,
-				"shared.locks.expiresAt": bson.M{
-					"$gt": minExpiresAt,
+				"resource": lock.Resource,
+				"shared.locks": bson.M{
+					"$elemMatch": bson.M{
+						"lockId": lock.LockId,
+						"expiresAt": bson.M{
+							"$gt": primitive.NewDateTimeFromTime(minExpiresAt),
+						},
+					},
 				},
 			}
 

--- a/lock_test.go
+++ b/lock_test.go
@@ -745,8 +745,16 @@ func TestRenew(t *testing.T) {
 
 	client := lock.NewClient(collection)
 
+	// Create a lock that we are not renewing on a resource that will get another
+	// lock that we will attempt to renew. If the renew operation is done wrong
+	// this lock will be renewed instead of the proper one.
+	err := client.SLock(ctx, "resource4", "cccc", lock.LockDetails{TTL: 3600}, -1)
+	if err != nil {
+		t.Error(err)
+	}
+
 	// Create some locks.
-	err := client.XLock(ctx, "resource1", "aaaa", lock.LockDetails{TTL: 3600})
+	err = client.XLock(ctx, "resource1", "aaaa", lock.LockDetails{TTL: 3600})
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Through testing I have discovered that AWS DocumentDB does not seem to like the BSON produced when directly using `time.Time` in `FindOneAndUpdate`. Switching to using `primitive.NewDateTimeFromTime` works with both MongoDB and DocumentDB.

Updated the selector for shared locks in `Renew` to use `$elemMatch` instead of dot notation. Per the [Mongodb documenation](https://www.mongodb.com/docs/manual/tutorial/query-array-of-documents/#specify-multiple-conditions-for-array-of-documents) the dot notation with respect to array elements only ensures that some combination of array elements in the document meet the query requirements. `$elemMatch` requires that at least one array element meets _all_ of the query requirements, which is what we want to have happen in `Renew`. The updates to the `TestRenew` unit test demonstrate this. If run using dot notation the lock `cccc` is renewed instead of `aaaa` which is not the intended behavior.