### PR TITLE
implemented simple gc of released loc entries in mongo collection

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -684,6 +684,21 @@ func (c *Client) sUnlock(ctx context.Context, resourceName, lockId string) error
 	return nil
 }
 
+// Gc removes all lock entries in the collection that have expired
+// Specifically this removes lock entries where exclusive.lockId is nil AND shared.count is 0
+func (c *Client) Gc(ctx context.Context) error {
+	// Get all empty locks and remove
+	selector := bson.A{
+		bson.D{{Key: "exclusive.lockId", Value: nil}},
+		bson.D{{Key: "shared.count", Value: 0}},
+	}
+	_, err := c.collection.DeleteMany(ctx, selector)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // lockFromDetails creates a lock struct from a lockId and a LockDetails struct.
 func lockFromDetails(lockId string, ld LockDetails) lock {
 	now := time.Now()

--- a/lock.go
+++ b/lock.go
@@ -688,10 +688,9 @@ func (c *Client) sUnlock(ctx context.Context, resourceName, lockId string) error
 // Specifically this removes lock entries where exclusive.lockId is nil AND shared.count is 0
 func (c *Client) Gc(ctx context.Context) error {
 	// Get all empty locks and remove
-	selector := bson.A{
-		bson.D{{Key: "exclusive.lockId", Value: nil}},
-		bson.D{{Key: "shared.count", Value: 0}},
-	}
+	selector := bson.M{"exclusive.lockId": nil,
+		"shared.count": 0}
+
 	_, err := c.collection.DeleteMany(ctx, selector)
 	if err != nil {
 		return err

--- a/lock.go
+++ b/lock.go
@@ -688,8 +688,10 @@ func (c *Client) sUnlock(ctx context.Context, resourceName, lockId string) error
 // Specifically this removes lock entries where exclusive.lockId is nil AND shared.count is 0
 func (c *Client) Gc(ctx context.Context) error {
 	// Get all empty locks and remove
-	selector := bson.M{"exclusive.lockId": nil,
-		"shared.count": 0}
+	selector := bson.M{
+		"exclusive.lockId": nil,
+		"shared.count":     0,
+	}
 
 	_, err := c.collection.DeleteMany(ctx, selector)
 	if err != nil {

--- a/purge.go
+++ b/purge.go
@@ -45,6 +45,11 @@ func (p *purger) Purge(ctx context.Context) ([]LockStatus, error) {
 		}
 		allUnlocked = append(allUnlocked, unlocked...)
 	}
+	// Garbage collect unused lock records
+	err = p.client.Gc(ctx)
+	if err != nil {
+		return allUnlocked, err
+	}
 
 	return allUnlocked, nil
 }


### PR DESCRIPTION
Removes entries in the mongo collection that belong to release locks.

The following query 	
`selector := bson.M{
		"exclusive.lockId": nil,
		"shared.count":     0,
	}
`
is used to select entries to remove.

See issue https://github.com/square/mongo-lock/issues/17